### PR TITLE
Resolve Intel vs Apple Silicon

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -20,3 +20,8 @@ alias p5='p +5'
 alias dv='dirs -v'
 
 alias killCheatSheet='ps ax | grep Cheat | grep -v grep | pcol 1 | xargs kill'
+
+#
+# Atlassian forge shell completion
+# forge is (currently) installed "in" nvm use 16, thus here's an alias to setup completion:
+alias setupForgeCompletion='. <(forge --completion)'


### PR DESCRIPTION
To support using forge-cli installed "in nvm", a setup alias is needed -> -> cannot be setup globally.